### PR TITLE
update with bound from high-mass-ratio LIGO mergers

### DIFF
--- a/bounds/LIGO-HMR.txt
+++ b/bounds/LIGO-HMR.txt
@@ -1,0 +1,10 @@
+# Black curve from Fig 5. of https://arxiv.org/abs/2007.03583
+# data from https://github.com/gwastro/stellar-pbh-search
+0.01     3.7256
+0.03     2.3842e-01
+0.05     7.4799e-02
+0.10     3.0375e-02
+0.30     8.1303e-03
+0.50     5.5777e-03
+0.75     3.4464e-03
+1.00     2.8035e-03

--- a/listfiles/bounds_GW.txt
+++ b/listfiles/bounds_GW.txt
@@ -1,3 +1,4 @@
 # Bound, colour, linestyle, x, y, rotation
 LIGO	C4	-	1e1	2.5e-3	-41	Mergers
 LIGO-SGWB	C4	-	5	3e-2	-30	Stochastic_background
+LIGO-HMR C4 - 0.2 7e-3 -50 High-mass-ratio_Mergers

--- a/listfiles/bounds_GWsonly.txt
+++ b/listfiles/bounds_GWsonly.txt
@@ -2,9 +2,8 @@
 OGLE?	k	:	1e-5	2.2e-2	-75
 LIGO	r	-	1e1	2e-3	-75
 LIGO-SGWB	r	-	10	2e-2	-60
-NANOGrav	r	-	2e-2	1e-2	0
+NANOGrav	r	-	3e-2	2e-3	0
 GW-Lensing	r	--	1e3	2e-1	-70
 PBH-EMRIs	r	--	2e-6	0.3	-76
 SIGWs	r	--	0	0	0
-
-
+LIGO-HMR r - .5 .01 -75


### PR DESCRIPTION
This adds our bounds from https://arxiv.org/abs/2007.03583 for the high-mass-ratio mergers of stellar-mass and sub-solar mass black holes. 